### PR TITLE
Abstracting TenableIoClient into TestBase to reduce number of threads

### DIFF
--- a/src/test/java/com/tenable/io/api/AgentConfigApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/AgentConfigApiClientTest.java
@@ -15,12 +15,10 @@ import static org.junit.Assert.assertTrue;
  * Copyright (c) 2017 Tenable Network Security, Inc.
  */
 public class AgentConfigApiClientTest extends TestBase {
-    private TenableIoClient apiClient;
     private Scanner scanner;
 
     @Before
     public void setUp() throws Exception {
-        apiClient = new TenableIoClient();
         List<Scanner> scanners = apiClient.getScannersApi().list();
         assertNotNull( scanners );
 

--- a/src/test/java/com/tenable/io/api/AgentExclusionsApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/AgentExclusionsApiClientTest.java
@@ -21,13 +21,11 @@ import static org.junit.Assert.*;
  * Copyright (c) 2017 Tenable Network Security, Inc.
  */
 public class AgentExclusionsApiClientTest extends TestBase {
-    private TenableIoClient apiClient;
     private Scanner scanner;
     private Exclusion createdExclusion;
 
     @Before
     public void setUp() throws Exception {
-        apiClient = new TenableIoClient();
         List<Scanner> scanners = apiClient.getScannersApi().list();
         assertNotNull( scanners );
 

--- a/src/test/java/com/tenable/io/api/AgentGroupsApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/AgentGroupsApiClientTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.*;
  * Copyright (c) 2017 Tenable Network Security, Inc.
  */
 public class AgentGroupsApiClientTest extends TestBase {
-    private TenableIoClient apiClient = new TenableIoClient();
 
     @Test
     public void testAgentGroups() throws Exception {
@@ -95,8 +94,6 @@ public class AgentGroupsApiClientTest extends TestBase {
     @Before
     @After
     public void cleanup() throws TenableIoException {
-        TenableIoClient apiClient = new TenableIoClient();
-
         deleteTestAgentGroups(apiClient);
     }
 }

--- a/src/test/java/com/tenable/io/api/AgentsApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/AgentsApiClientTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
  */
 public class AgentsApiClientTest extends TestBase {
     private final String limit = "50";
-    private TenableIoClient apiClient = new TenableIoClient();
     private AgentFilterOptions filterOptions;
     private List<Agent> agents;
 

--- a/src/test/java/com/tenable/io/api/AssetImportApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/AssetImportApiClientTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertNotNull;
  * Copyright (c) 2017 Tenable Network Security, Inc.
  */
 public class AssetImportApiClientTest extends TestBase {
-    private TenableIoClient apiClient = new TenableIoClient();
     private String path = "src/test/resources/mock_assets.json";
 
      @Test

--- a/src/test/java/com/tenable/io/api/BulkAgentApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/BulkAgentApiClientTest.java
@@ -16,12 +16,10 @@ import static org.junit.Assert.*;
  * Copyright (c) 2017 Tenable Network Security, Inc.
  */
 public class BulkAgentApiClientTest extends TestBase {
-    private TenableIoClient apiClient;
     private Scanner scanner;
 
     @Before
     public void setUp() throws Exception {
-        apiClient = new TenableIoClient();
         List<Scanner> scanners = apiClient.getScannersApi().list();
         assertNotNull( scanners );
 

--- a/src/test/java/com/tenable/io/api/EditorApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/EditorApiClientTest.java
@@ -24,7 +24,6 @@ public class EditorApiClientTest extends TestBase {
 
     @Test
     public void testList() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         List<Template> policyTemplates = apiClient.getEditorApi().list( TemplateType.POLICY );
         assertNotNull( policyTemplates );
         assertTrue( policyTemplates.size() > 0 );
@@ -37,7 +36,6 @@ public class EditorApiClientTest extends TestBase {
 
     @Test
     public void testDetails() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         List<Template> policyTemplates = apiClient.getEditorApi().list( TemplateType.POLICY );
         assertNotNull( policyTemplates );
         assertTrue( policyTemplates.size() > 0 );
@@ -53,7 +51,6 @@ public class EditorApiClientTest extends TestBase {
 
     @Test
     public void testAgent() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         List<Template> policyTemplates = apiClient.getEditorApi().list( TemplateType.POLICY );
         assertNotNull( policyTemplates );
         assertTrue( policyTemplates.size() > 0 );
@@ -75,8 +72,6 @@ public class EditorApiClientTest extends TestBase {
 
     @Test
     public void testPluginDescription() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         // import a policy to be used in test
         String filename = apiClient.getFileApi().upload( new File( "src/test/resources/nessus_policy_test.nessus" ) );
         Policy imported = apiClient.getPoliciesApi().importPolicy( filename );

--- a/src/test/java/com/tenable/io/api/ExclusionsApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/ExclusionsApiClientTest.java
@@ -23,7 +23,6 @@ public class ExclusionsApiClientTest extends TestBase {
     @Test
     public void testExclusions() throws Exception {
 
-        TenableIoClient apiClient = new TenableIoClient();
         //list
         List<Exclusion> result = apiClient.getExclusionsApi().list();
         assertNotNull( result );
@@ -74,8 +73,6 @@ public class ExclusionsApiClientTest extends TestBase {
     @Before
     @After
     public void cleanup() throws TenableIoException {
-        TenableIoClient apiClient = new TenableIoClient();
-
         deleteTestExclusions( apiClient );
     }
 }

--- a/src/test/java/com/tenable/io/api/FileApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/FileApiClientTest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.*;
 public class FileApiClientTest extends TestBase {
     @Test
     public void testFileUpload() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         String filename = apiClient.getFileApi().upload( new File( "src/test/resources/targets.txt" ) );
 
         assertNotNull( filename );

--- a/src/test/java/com/tenable/io/api/FiltersApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/FiltersApiClientTest.java
@@ -18,7 +18,6 @@ public class FiltersApiClientTest extends TestBase {
 
     @Test
     public void testFilters() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         List<Filter> filters = apiClient.getFiltersApi().workbenchesVulnerabilities();
         assertNotNull( filters );
 

--- a/src/test/java/com/tenable/io/api/FoldersApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/FoldersApiClientTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.*;
 public class FoldersApiClientTest extends TestBase {
     @Test
     public void testCreateAndDelete() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         int folderId = createFolder( apiClient );
 
         apiClient.getFoldersApi().delete( folderId );
@@ -30,7 +29,6 @@ public class FoldersApiClientTest extends TestBase {
 
     @Test
     public void testListFolders() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         int folderId = createFolder( apiClient );
 
         List<Folder> folders = apiClient.getFoldersApi().list();
@@ -44,7 +42,6 @@ public class FoldersApiClientTest extends TestBase {
 
     @Test
     public void testEditFolder() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         int folderId = createFolder( apiClient );
 
         apiClient.getFoldersApi().edit( folderId, "newName" );
@@ -80,8 +77,6 @@ public class FoldersApiClientTest extends TestBase {
     @Before
     @After
     public void cleanup() throws TenableIoException {
-        TenableIoClient apiClient = new TenableIoClient();
-
         deleteTestFolders( apiClient );
     }
 }

--- a/src/test/java/com/tenable/io/api/GroupsApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/GroupsApiClientTest.java
@@ -26,7 +26,6 @@ public class GroupsApiClientTest extends TestBase {
 
     @Test
     public void testGroup() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         //create new group
         String testGroupsName = getNewTestGroupName();
         apiClient.getUserGroupsApi().create( testGroupsName );
@@ -95,7 +94,6 @@ public class GroupsApiClientTest extends TestBase {
 
     @Test
     public void testGroupEdit() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         //create new group
         String testGroupsName = getNewTestGroupName();
         apiClient.getUserGroupsApi().create( testGroupsName );
@@ -153,8 +151,6 @@ public class GroupsApiClientTest extends TestBase {
 
 
     private void deleteTestData() throws TenableIoException {
-        TenableIoClient apiClient = new TenableIoClient();
-
         deleteTestGroups( apiClient );
     }
 }

--- a/src/test/java/com/tenable/io/api/PermissionsApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/PermissionsApiClientTest.java
@@ -22,8 +22,6 @@ import static org.junit.Assert.*;
 public class PermissionsApiClientTest extends TestBase {
     @Test
     public void testPermission() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         //create an asset list with custom permission
         Permission permission = new Permission().withType( "default" ).withPermissions( 64 );
         List<Permission> acls = new ArrayList<Permission>();
@@ -70,8 +68,6 @@ public class PermissionsApiClientTest extends TestBase {
     @Before
     @After
     public void cleanup() throws TenableIoException {
-        TenableIoClient apiClient = new TenableIoClient();
-
         deleteTestTargetGroups( apiClient );
     }
 }

--- a/src/test/java/com/tenable/io/api/PluginsApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/PluginsApiClientTest.java
@@ -20,7 +20,6 @@ public class PluginsApiClientTest extends TestBase {
 
     @Test
     public void testPlugins() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         List<PluginFamily> pluginFamilies = apiClient.getPluginsApi().families();
 
         assertNotNull( pluginFamilies );

--- a/src/test/java/com/tenable/io/api/PoliciesApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/PoliciesApiClientTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.*;
 public class PoliciesApiClientTest extends TestBase {
     @Test
     public void testList() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         List<Policy> result = apiClient.getPoliciesApi().list();
 
         assertNotNull( result );
@@ -33,7 +32,6 @@ public class PoliciesApiClientTest extends TestBase {
 
     @Test
     public void testCreateAndDelete() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         // makes sure user exists
         User user = createTestUser( apiClient, 0 );
         PolicyCreateResponse response = createPolicy( apiClient, user );
@@ -46,7 +44,6 @@ public class PoliciesApiClientTest extends TestBase {
 
     @Test
     public void testCreateAndCopyAndDelete() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         // makes sure user exists
         User user = createTestUser( apiClient, 0 );
         PolicyCreateResponse response = createPolicy( apiClient, user );
@@ -64,8 +61,6 @@ public class PoliciesApiClientTest extends TestBase {
 
     @Test
     public void testDetails() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         // makes sure user exists
         User user = createTestUser( apiClient, 0 );
         PolicyCreateResponse response = createPolicy( apiClient, user );
@@ -83,8 +78,6 @@ public class PoliciesApiClientTest extends TestBase {
 
     @Test
     public void testConfigure() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         // makes sure user exists
         User user = createTestUser( apiClient, 0 );
         //create
@@ -112,8 +105,6 @@ public class PoliciesApiClientTest extends TestBase {
 
     @Test
     public void testExportPolicy() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         // makes sure user exists
         User user = createTestUser( apiClient, 0 );
         //makes sure we have at least one policy
@@ -137,8 +128,6 @@ public class PoliciesApiClientTest extends TestBase {
 
     @Test
     public void testImportPolicy() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         String filename = apiClient.getFileApi().upload( new File( "src/test/resources/nessus_policy_test.nessus" ) );
         Policy imported = apiClient.getPoliciesApi().importPolicy( filename );
         assertNotNull( imported );
@@ -238,8 +227,6 @@ public class PoliciesApiClientTest extends TestBase {
     @Before
     @After
     public void cleanup() throws TenableIoException {
-        TenableIoClient apiClient = new TenableIoClient();
-
         deleteTestPolicies( apiClient );
     }
 }

--- a/src/test/java/com/tenable/io/api/ScannerGroupsApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/ScannerGroupsApiClientTest.java
@@ -22,8 +22,6 @@ import static org.junit.Assert.*;
 public class ScannerGroupsApiClientTest extends TestBase {
     @Test
     public void testScannerGroups() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         //create scanner group
         String name = getNewTestScannerGroupName();
         ScannerGroup createdGroup = apiClient.getScannerGroupsApi().create( name, ScannerGroupType.LOAD_BALANCING );
@@ -78,8 +76,6 @@ public class ScannerGroupsApiClientTest extends TestBase {
     @Before
     @After
     public void cleanup() throws TenableIoException {
-        TenableIoClient apiClient = new TenableIoClient();
-
         deleteTestScannerGroups( apiClient );
     }
 }

--- a/src/test/java/com/tenable/io/api/ScannersApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/ScannersApiClientTest.java
@@ -23,7 +23,6 @@ public class ScannersApiClientTest extends TestBase {
     @Ignore("CI-16038")
     @Test
     public void testScanners() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         List<Scanner> scanners = apiClient.getScannersApi().list();
 
         assertNotNull( scanners );
@@ -55,7 +54,6 @@ public class ScannersApiClientTest extends TestBase {
 
     @Test
     public void testGetScans() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         List<Scanner> scanners = apiClient.getScannersApi().list();
 
         assertNotNull( scanners );
@@ -72,7 +70,6 @@ public class ScannersApiClientTest extends TestBase {
     @Ignore("CI-16726")
     @Test
     public void testControlScans() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         List<Scanner> scanners = apiClient.getScannersApi().list();
         assertNotNull( scanners );
 
@@ -131,8 +128,6 @@ public class ScannersApiClientTest extends TestBase {
     @Before
     @After
     public void cleanup() throws TenableIoException {
-        TenableIoClient apiClient = new TenableIoClient();
-
         // No longer needed on temporary test containers
         // deleteTestScans( apiClient );
     }

--- a/src/test/java/com/tenable/io/api/ScansApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/ScansApiClientTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.*;
 public class ScansApiClientTest extends TestBase {
     @Test
     public void testTimeZones() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         TimezonesResult result = apiClient.getScansApi().timezones();
 
         assertNotNull( result );
@@ -36,7 +35,6 @@ public class ScansApiClientTest extends TestBase {
 
     @Test
     public void testCreateAndLaunch() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         int folderId = apiClient.getFoldersApi().create( getNewTestFolderName() );
         ScanResult result = createScan( apiClient, folderId );
 
@@ -55,7 +53,6 @@ public class ScansApiClientTest extends TestBase {
 
     @Test
     public void testScansList() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         ScanListResult result = apiClient.getScansApi().list();
         ScanDetails details = apiClient.getScansApi().details( result.getScans().get( 0 ).getId() );
         assertNotNull( result );
@@ -64,7 +61,6 @@ public class ScansApiClientTest extends TestBase {
 
     @Test
     public void testPauseAndResume() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         int folderId = apiClient.getFoldersApi().create( getNewTestFolderName() );
         ScanResult result = createScan( apiClient, folderId );
         //launch the scan
@@ -90,7 +86,6 @@ public class ScansApiClientTest extends TestBase {
 
     @Test
     public void testStopAndCancel() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         int folderId = apiClient.getFoldersApi().create( getNewTestFolderName() );
         ScanResult result = createScan( apiClient, folderId );
 
@@ -112,7 +107,6 @@ public class ScansApiClientTest extends TestBase {
 
     @Test
     public void testSchedule() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         int folderId = apiClient.getFoldersApi().create( getNewTestFolderName() );
         ScanResult result = createScan( apiClient, folderId );
 
@@ -151,7 +145,6 @@ public class ScansApiClientTest extends TestBase {
 
     @Test
     public void testDownload() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         ScanListResult result = apiClient.getScansApi().list();
         ScanDetails details = apiClient.getScansApi().details( result.getScans().get( 0 ).getId() );
 
@@ -172,7 +165,6 @@ public class ScansApiClientTest extends TestBase {
 
     @Test
     public void testCopyScan() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         int folderId = apiClient.getFoldersApi().create( getNewTestFolderName() );
         ScanResult newScan = createScan( apiClient, folderId );
         assertNotNull( newScan );
@@ -189,7 +181,6 @@ public class ScansApiClientTest extends TestBase {
 
     @Test
     public void testImportScan() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         String filename = apiClient.getFileApi().upload( new File( "src/test/resources/sdk_import_test.nessus" ) );
         assertNotNull( filename );
         //password must be the same used when exporting the scan
@@ -202,7 +193,6 @@ public class ScansApiClientTest extends TestBase {
 
     @Test
     public void testConfigure() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         int folderId = apiClient.getFoldersApi().create( getNewTestFolderName() );
         ScanResult newScan = createScan( apiClient, folderId );
         assertNotNull( newScan );
@@ -270,7 +260,6 @@ public class ScansApiClientTest extends TestBase {
     @Ignore("501 - delete-history not implemented")
     @Test
     public void testDeleteHistory() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         int folderId = apiClient.getFoldersApi().create( getNewTestFolderName() );
         ScanResult newScan = createScan( apiClient, folderId );
         assertNotNull( newScan );
@@ -351,8 +340,6 @@ public class ScansApiClientTest extends TestBase {
     @Before
     @After
     public void cleanup() throws TenableIoException {
-        TenableIoClient apiClient = new TenableIoClient();
-
         deleteTestFolders( apiClient );
     }
 }

--- a/src/test/java/com/tenable/io/api/ServerApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/ServerApiClientTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.*;
 public class ServerApiClientTest extends TestBase {
     @Test
     public void testServer() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         ServerStatus status = apiClient.getServerApi().status();
         assertNotNull( status );
 

--- a/src/test/java/com/tenable/io/api/TargetGroupsApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/TargetGroupsApiClientTest.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.assertTrue;
 public class TargetGroupsApiClientTest extends TestBase {
     @Test
     public void testTargetGroups() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         //create asset list
         User user = createTestUser( apiClient, 0 );
 
@@ -83,8 +81,6 @@ public class TargetGroupsApiClientTest extends TestBase {
     @Before
     @After
     public void cleanup() throws TenableIoException {
-        TenableIoClient apiClient = new TenableIoClient();
-
         deleteTestTargetGroups( apiClient );
     }
 }

--- a/src/test/java/com/tenable/io/api/TestBase.java
+++ b/src/test/java/com/tenable/io/api/TestBase.java
@@ -61,8 +61,11 @@ public class TestBase {
 
     @After
     public void cleanupBase() throws TenableIoException {
-        deleteTestData();
-        closeClient();
+        try {
+            deleteTestData();
+        } finally {
+            closeClient();
+        }
     }
 
 

--- a/src/test/java/com/tenable/io/api/TestBase.java
+++ b/src/test/java/com/tenable/io/api/TestBase.java
@@ -54,9 +54,15 @@ public class TestBase {
     private String policyTemplateName = System.getProperty( "policyTemplateName" );
 
 
+    @Before
+    public void preChecksBase() throws TenableIoException {
+        deleteTestData();
+    }
+
     @After
     public void cleanupBase() throws TenableIoException {
         deleteTestData();
+        closeClient();
     }
 
 
@@ -110,6 +116,13 @@ public class TestBase {
         return user;
     }
 
+    private void closeClient() {
+        try {
+            apiClient.close();
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+    }
 
     private void deleteTestData() throws TenableIoException {
         //delete potential test users
@@ -129,12 +142,6 @@ public class TestBase {
                     apiClient.getUsersApi().delete( user.getId() );
                 }
             }
-        }
-
-        try {
-            apiClient.close();
-        } catch (Exception e) {
-            System.out.println(e);
         }
     }
 

--- a/src/test/java/com/tenable/io/api/TestBase.java
+++ b/src/test/java/com/tenable/io/api/TestBase.java
@@ -38,7 +38,7 @@ public class TestBase {
     protected static final String TEST_SCANNER_GROUP_NAME_PREFIX = "tioTestScannerGroup_";
 
 
-
+    protected TenableIoClient apiClient = new TenableIoClient();
     private static final String testUsernameBase = "tioTestUsername";
     private Set<String> testUsernames = new HashSet<>();
 
@@ -53,11 +53,6 @@ public class TestBase {
     // Name of template to create a policy with.
     private String policyTemplateName = System.getProperty( "policyTemplateName" );
 
-
-    @Before
-    public void preChecksBase() throws TenableIoException {
-        deleteTestData();
-    }
 
     @After
     public void cleanupBase() throws TenableIoException {
@@ -117,8 +112,6 @@ public class TestBase {
 
 
     private void deleteTestData() throws TenableIoException {
-        TenableIoClient apiClient = new TenableIoClient();
-
         //delete potential test users
         List<User> users = apiClient.getUsersApi().list();
         if( users != null ) {
@@ -136,6 +129,12 @@ public class TestBase {
                     apiClient.getUsersApi().delete( user.getId() );
                 }
             }
+        }
+
+        try {
+            apiClient.close();
+        } catch (Exception e) {
+            System.out.println(e);
         }
     }
 

--- a/src/test/java/com/tenable/io/api/UsersApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/UsersApiClientTest.java
@@ -20,8 +20,6 @@ import static org.junit.Assert.*;
 public class UsersApiClientTest extends TestBase {
     @Test
     public void testCreateAndDelete() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         User user = createTestUser( apiClient );
 
         assertNotNull( user );
@@ -41,7 +39,6 @@ public class UsersApiClientTest extends TestBase {
 
     @Test
     public void testUserDetails() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         List<User> users = apiClient.getUsersApi().list();
 
         assertTrue( users.size() > 0 );
@@ -59,8 +56,6 @@ public class UsersApiClientTest extends TestBase {
 
     @Test
     public void testEditUser() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         User user = createTestUser( apiClient );
 
         assertNotNull( user );
@@ -85,8 +80,6 @@ public class UsersApiClientTest extends TestBase {
 
     @Test
     public void testImpersonateUser() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         List<User> users = apiClient.getUsersApi().list();
 
         assertTrue( users.size() > 0 );
@@ -101,8 +94,6 @@ public class UsersApiClientTest extends TestBase {
 
     @Test
     public void testChangePassword() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         User user = createTestUser( apiClient );
 
         assertNotNull( user );
@@ -117,8 +108,6 @@ public class UsersApiClientTest extends TestBase {
 
     @Test
     public void testUserKeys() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         User user = createTestUser( apiClient );
 
         assertNotNull( user );
@@ -137,7 +126,6 @@ public class UsersApiClientTest extends TestBase {
 
     @Test
     public void testEnableDisabledUser() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         User user = createTestUser( apiClient );
         assertNotNull( user );
         int userId = user.getId();
@@ -156,7 +144,6 @@ public class UsersApiClientTest extends TestBase {
 
     @Test
     public void testTwoFactor() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         User user = createTestUser( apiClient );
         assertNotNull( user );
         int userId = user.getId();

--- a/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
@@ -113,7 +113,6 @@ public class WorkbenchesApiClientTest extends TestBase {
 
             // wait for vulnerability output details to be ready
             tries = 0;
-            maxTries = 3;
             while (assetVulnerabilityOutput.size() == 0) {
                 Thread.sleep(10000);
                 assetVulnerabilityOutput = apiClient.getWorkbenchesApi()
@@ -159,9 +158,14 @@ public class WorkbenchesApiClientTest extends TestBase {
                 .withFilters(filters));
 
 
+        int tries = 0;
+        int maxTries = 10;
         while( !"ready".equals( apiClient.getWorkbenchesApi().exportStatus( fileId ) ) ) {
             try {
                 Thread.sleep( 5000 );
+                if (tries++ == maxTries) {
+                    fail("Export did not reach a \"ready\" state");
+                }
             } catch( InterruptedException e ) {}
         }
 

--- a/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
@@ -86,9 +86,14 @@ public class WorkbenchesApiClientTest extends TestBase {
                     assets.get(0).getId(), new FilteringOptions());
             
             // wait for vulnerability details in scan results to be processed
+            int tries = 0;
+            int maxTries = 3;
             while (vulnerabilities.size() == 0) {
                 Thread.sleep(10000);
                 vulnerabilities = apiClient.getWorkbenchesApi().assetVulnerabilities(assets.get(0).getId(), new FilteringOptions());
+                if (tries++ == maxTries) {
+                    fail("Could not retrieve vulnerabilities using assetVulnerabilities");
+                }
             }
             assertNotNull(vulnerabilities);
             assertTrue( vulnerabilities.size() > 0 );
@@ -107,11 +112,16 @@ public class WorkbenchesApiClientTest extends TestBase {
                             new FilteringOptions());
 
             // wait for vulnerability output details to be ready
+            tries = 0;
+            maxTries = 3;
             while (assetVulnerabilityOutput.size() == 0) {
                 Thread.sleep(10000);
                 assetVulnerabilityOutput = apiClient.getWorkbenchesApi()
                     .assetVulnerabilityOutput(assets.get(0).getId(), vulnerabilities.get(0).getPluginId(),
                             new FilteringOptions());
+                if (tries++ == maxTries) {
+                    fail("Could not retrieve vulnerabilities using assetVulnerabilityOutput");
+                }
             }
             assertNotNull(assetVulnerabilityOutput);
             assertTrue(assetVulnerabilityOutput.size() > 0);

--- a/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
@@ -25,8 +25,6 @@ public class WorkbenchesApiClientTest extends TestBase {
 
     @Test
     public void testVulnerabilities() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         List<ScanVulnerability> result = apiClient.getWorkbenchesApi().vulnerabilities( new ExtendedFilteringOptions() );
         if(result != null && result.size() > 0) {
             assertNotNull(result.get(0));
@@ -63,8 +61,6 @@ public class WorkbenchesApiClientTest extends TestBase {
 
     @Test
     public void testAssets() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
-
         // Assets need to be imported prior to running this otherwise asset count will be 0
         String filename = apiClient.getFileApi().upload( new File( "src/test/resources/sdk_import_test.nessus" ) );
         assertNotNull( filename );
@@ -137,8 +133,6 @@ public class WorkbenchesApiClientTest extends TestBase {
 
     @Test
     public void testWorkbenchExport() throws Exception {
-
-        TenableIoClient apiClient = new TenableIoClient();
 
         File destinationFile = new File("src/test/resources/workbenchTest.nessus");
 
@@ -213,7 +207,6 @@ public class WorkbenchesApiClientTest extends TestBase {
     }
 
     private int getPluginId() throws Exception {
-        TenableIoClient apiClient = new TenableIoClient();
         List<PluginFamily> pluginFamilies = apiClient.getPluginsApi().families();
         PluginFamilyDetail familyDetails = apiClient.getPluginsApi().familyDetails( pluginFamilies.get( 0 ).getId() );
         PluginDetail pluginDetails = apiClient.getPluginsApi().pluginDetails( familyDetails.getPlugins().get( 0 ).getId() );

--- a/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
@@ -67,11 +67,11 @@ public class WorkbenchesApiClientTest extends TestBase {
         Scan imported = apiClient.getScansApi().importFile( filename, "test", "1");
         assertNotNull( imported );
 
-        Filter isLicensedFilter = new Filter()
-                .withFilter("is_licensed")
+        Filter ipFilter = new Filter()
+                .withFilter("ipv4")
                 .withQuality(FilterOperator.EQUAL)
-                .withValue("true");
-        FilteringOptions filterOptions = new FilteringOptions().withFilters(Arrays.asList(isLicensedFilter));
+                .withValue("10.10.10.1");
+        FilteringOptions filterOptions = new FilteringOptions().withFilters(Arrays.asList(ipFilter));
         List<WbVulnerabilityAsset> assets = apiClient.getWorkbenchesApi().assets(filterOptions);
         
         // wait for assets in scan results to be processed

--- a/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
@@ -66,7 +66,13 @@ public class WorkbenchesApiClientTest extends TestBase {
         assertNotNull( filename );
         Scan imported = apiClient.getScansApi().importFile( filename, "test", "1");
         assertNotNull( imported );
-        List<WbVulnerabilityAsset> assets = apiClient.getWorkbenchesApi().assets(new FilteringOptions());
+
+        Filter isLicensedFilter = new Filter()
+                .withFilter("is_licensed")
+                .withQuality(FilterOperator.EQUAL)
+                .withValue("true");
+        FilteringOptions filterOptions = new FilteringOptions().withFilters(Arrays.asList(isLicensedFilter));
+        List<WbVulnerabilityAsset> assets = apiClient.getWorkbenchesApi().assets(filterOptions);
         
         // wait for assets in scan results to be processed
         while (assets.size() == 0) {
@@ -87,7 +93,7 @@ public class WorkbenchesApiClientTest extends TestBase {
             
             // wait for vulnerability details in scan results to be processed
             int tries = 0;
-            int maxTries = 3;
+            int maxTries = 6;
             while (vulnerabilities.size() == 0) {
                 Thread.sleep(10000);
                 vulnerabilities = apiClient.getWorkbenchesApi().assetVulnerabilities(assets.get(0).getId(), new FilteringOptions());

--- a/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/WorkbenchesApiClientTest.java
@@ -77,7 +77,7 @@ public class WorkbenchesApiClientTest extends TestBase {
         // wait for assets in scan results to be processed
         while (assets.size() == 0) {
             Thread.sleep(10000);
-            assets = apiClient.getWorkbenchesApi().assets(new FilteringOptions());
+            assets = apiClient.getWorkbenchesApi().assets(filterOptions);
         }
 
         if(assets != null && assets.size() > 0) {


### PR DESCRIPTION
When running the unit tests locally, we were seeing OutOfMemoryExceptions due to a high number of active threads. This PR should fix that issue by reusing an API client across tests and closing that client on JUnit's teardown phase.