### PR TITLE
Api and jackson fixes

### DIFF
--- a/src/main/java/com/tenable/io/api/plugins/models/PluginOutputResult.java
+++ b/src/main/java/com/tenable/io/api/plugins/models/PluginOutputResult.java
@@ -9,7 +9,7 @@ import java.util.List;
  */
 public class PluginOutputResult {
     private PluginOutputInfo info;
-    private List<PluginOutput> output;
+    private List<PluginOutput> outputs;
 
 
     /**
@@ -37,17 +37,17 @@ public class PluginOutputResult {
      *
      * @return the plugin output lis
      */
-    public List<PluginOutput> getOutput() {
-        return output;
+    public List<PluginOutput> getOutputs() {
+        return outputs;
     }
 
 
     /**
      * Sets the plugin output list.
      *
-     * @param output the plugin output list
+     * @param outputs the plugin output list
      */
-    public void setOutput( List<PluginOutput> output ) {
-        this.output = output;
+    public void setOutputs(List<PluginOutput> outputs) {
+        this.outputs = outputs;
     }
 }

--- a/src/main/java/com/tenable/io/api/scans/models/ScanDetails.java
+++ b/src/main/java/com/tenable/io/api/scans/models/ScanDetails.java
@@ -105,7 +105,7 @@ public class ScanDetails {
         ObjectMapper mapper = new ObjectMapper();
 
         try {
-            this.notes = mapper.readValue(notes.toString(), new TypeReference<NotesRoot>() {} );
+            this.notes = mapper.readValue(notes.toString(), new TypeReference<NotesRoot>() {} ).getNote();
         } catch( Exception e ) {
             this.notes = notes;
         }

--- a/src/main/java/com/tenable/io/api/scans/models/ScanHostDetails.java
+++ b/src/main/java/com/tenable/io/api/scans/models/ScanHostDetails.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class ScanHostDetails {
     private ScanHostDetailsInfo info;
     private List<ScanHostCompliance> compliance;
-    private ScanHostVulnerability vulnerabilities;
+    private List<ScanHostVulnerability> vulnerabilities;
 
 
     /**
@@ -58,7 +58,7 @@ public class ScanHostDetails {
      *
      * @return the vulnerabilities list
      */
-    public ScanHostVulnerability getVulnerabilities() {
+    public List<ScanHostVulnerability> getVulnerabilities() {
         return vulnerabilities;
     }
 
@@ -68,7 +68,7 @@ public class ScanHostDetails {
      *
      * @param vulnerabilities the list of host vulnerabilities
      */
-    public void setVulnerabilities( ScanHostVulnerability vulnerabilities ) {
+    public void setVulnerabilities( List<ScanHostVulnerability> vulnerabilities ) {
         this.vulnerabilities = vulnerabilities;
     }
 }

--- a/src/main/java/com/tenable/io/api/scans/models/ScanHostDetailsInfo.java
+++ b/src/main/java/com/tenable/io/api/scans/models/ScanHostDetailsInfo.java
@@ -3,6 +3,8 @@ package com.tenable.io.api.scans.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 
 /**
  * Copyright (c) 2017 Tenable Network Security, Inc.
@@ -12,7 +14,7 @@ public class ScanHostDetailsInfo {
     private String macAddress;
     private String hostFqdn;
     private String hostEnd;
-    private String operatingSystem;
+    private List<String> operatingSystem;
     private String hostIp;
 
 
@@ -110,7 +112,7 @@ public class ScanHostDetailsInfo {
      * @return the operating system
      */
     @JsonProperty( "operating-system" )
-    public String getOperatingSystem() {
+    public List<String> getOperatingSystem() {
         return operatingSystem;
     }
 
@@ -121,7 +123,7 @@ public class ScanHostDetailsInfo {
      * @param operatingSystem the operating system
      */
     @JsonProperty( "operating-system" )
-    public void setOperatingSystem( String operatingSystem ) {
+    public void setOperatingSystem( List<String> operatingSystem ) {
         this.operatingSystem = operatingSystem;
     }
 

--- a/src/main/java/com/tenable/io/core/services/HttpFuture.java
+++ b/src/main/java/com/tenable/io/core/services/HttpFuture.java
@@ -189,7 +189,7 @@ public class HttpFuture {
      * @return an object of type A
      * @throws TenableIoException Thrown if the HTTP call errors out
      */
-    public <A> A getAsType( TypeReference valueTypeRef ) throws TenableIoException {
+    public <A> A getAsType( TypeReference<A> valueTypeRef ) throws TenableIoException {
         return asyncHttpService.getJsonHelper().fromJson( getAsString(), valueTypeRef );
     }
 
@@ -207,7 +207,7 @@ public class HttpFuture {
      * @return an object of type A
      * @throws TenableIoException Thrown if the HTTP call errors out
      */
-    public <A> A getAsType( TypeReference valueTypeRef, String root ) throws TenableIoException {
+    public <A> A getAsType( TypeReference<A> valueTypeRef, String root ) throws TenableIoException {
         return asyncHttpService.getJsonHelper().fromJson( getAsJson().get( root ), valueTypeRef );
     }
 

--- a/src/main/java/com/tenable/io/core/utilities/JsonHelper.java
+++ b/src/main/java/com/tenable/io/core/utilities/JsonHelper.java
@@ -88,7 +88,7 @@ public class JsonHelper {
      * @param valueTypeRef Expected Java value type.
      * @return the deserialized Java model
      */
-    public <A> A fromJson( JsonNode json, TypeReference valueTypeRef ) {
+    public <A> A fromJson( JsonNode json, TypeReference<A> valueTypeRef ) {
         try {
             return objectMapper.readValue( json.traverse(), valueTypeRef );
         } catch( Exception e ) {
@@ -123,7 +123,7 @@ public class JsonHelper {
      * @param valueTypeRef Expected Java value type.
      * @return the deserialized Java model
      */
-    public <A> A fromJson( String json, TypeReference valueTypeRef ) {
+    public <A> A fromJson( String json, TypeReference<A> valueTypeRef ) {
         try {
             return objectMapper.readValue( json, valueTypeRef );
         } catch( Exception e ) {


### PR DESCRIPTION
As said in issue #52 the incompatibilities between the API and the Java objects makes the SDK throw a `MismatchedInputException`.

Also, as the version of Jackson is specified as >=2.0.0, some things had to be changed, so it would work with newer versions.