### PR TITLE
Fixed MismatchedInputException for PluginOutput endpoint

### DIFF
--- a/src/main/java/com/tenable/io/api/workbenches/models/Reference.java
+++ b/src/main/java/com/tenable/io/api/workbenches/models/Reference.java
@@ -1,7 +1,7 @@
 package com.tenable.io.api.workbenches.models;
 
 
-import java.util.List;
+import com.fasterxml.jackson.databind.JsonNode;
 
 
 /**
@@ -11,7 +11,7 @@ public class Reference {
     private String ext;
     private String name;
     private String url;
-    private List<String> values;
+    private JsonNode values;
 
 
     /**
@@ -79,7 +79,7 @@ public class Reference {
      *
      * @return the values
      */
-    public List<String> getValues() {
+    public JsonNode getValues() {
         return values;
     }
 
@@ -89,7 +89,7 @@ public class Reference {
      *
      * @param values the values
      */
-    public void setValues( List<String> values ) {
+    public void setValues( JsonNode values ) {
         this.values = values;
     }
 }

--- a/src/main/java/com/tenable/io/api/workbenches/models/WbVulnerabilityInfoDetail.java
+++ b/src/main/java/com/tenable/io/api/workbenches/models/WbVulnerabilityInfoDetail.java
@@ -10,7 +10,7 @@ import java.util.List;
  * Copyright (c) 2017 Tenable Network Security, Inc.
  */
 public class WbVulnerabilityInfoDetail {
-    private String cpe;
+    private List<String> cpe;
     private String exploitAvailable;
     private String expoitabilityEase;
     private String patchPublicationDate;
@@ -23,7 +23,7 @@ public class WbVulnerabilityInfoDetail {
      *
      * @return the cpe
      */
-    public String getCpe() {
+    public List<String> getCpe() {
         return cpe;
     }
 
@@ -33,7 +33,7 @@ public class WbVulnerabilityInfoDetail {
      *
      * @param cpe the cpe
      */
-    public void setCpe( String cpe ) {
+    public void setCpe( List<String> cpe ) {
         this.cpe = cpe;
     }
 


### PR DESCRIPTION
I don't know if this was a recent API change, because I think it was working earlier, but anyway Jackson throws a MismatchedInputException
```
java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.lang.String` out of START_ARRAY token
``` 
for WbVulnerabilityInfoDetail and
```
java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.lang.String` out of START_OBJECT token
```
for the Reference class with these JSONs respectively:
```
...
"values": {
  "value": [ "CVE-2016-2183"  ]
},
...
```
and
```
"cpe":[
    "cpe:/a:apache:http_server"
]
```