### PR TITLE
Addressing several deserialization issues in the scans/wb APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group = 'com.tenable'
-version = '1.3-1'
+version = '1.3-2'
 
 description = """"""
 

--- a/src/main/java/com/tenable/io/api/scans/models/ScanHostCompliance.java
+++ b/src/main/java/com/tenable/io/api/scans/models/ScanHostCompliance.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ScanHostCompliance {
     private int hostId;
     private String hostname;
-    private int pluginId;
+    private String pluginId;
     private String pluginName;
     private String pluginFamily;
     private int count;
@@ -66,7 +66,7 @@ public class ScanHostCompliance {
      * @return the unique id of the vulnerability plugin.
      */
     @JsonProperty( "plugin_id" )
-    public int getPluginId() {
+    public String getPluginId() {
         return pluginId;
     }
 
@@ -77,7 +77,7 @@ public class ScanHostCompliance {
      * @param pluginId the unique id of the vulnerability plugin.
      */
     @JsonProperty( "plugin_id" )
-    public void setPluginId( int pluginId ) {
+    public void setPluginId( String pluginId ) {
         this.pluginId = pluginId;
     }
 

--- a/src/main/java/com/tenable/io/api/workbenches/models/Reference.java
+++ b/src/main/java/com/tenable/io/api/workbenches/models/Reference.java
@@ -11,7 +11,7 @@ public class Reference {
     private String ext;
     private String name;
     private String url;
-    private List<String> values;
+    private List<ReferenceValue> values;
 
 
     /**
@@ -79,7 +79,7 @@ public class Reference {
      *
      * @return the values
      */
-    public List<String> getValues() {
+    public List<ReferenceValue> getValues() {
         return values;
     }
 
@@ -89,7 +89,7 @@ public class Reference {
      *
      * @param values the values
      */
-    public void setValues( List<String> values ) {
+    public void setValues( List<ReferenceValue> values ) {
         this.values = values;
     }
 }

--- a/src/main/java/com/tenable/io/api/workbenches/models/ReferenceValue.java
+++ b/src/main/java/com/tenable/io/api/workbenches/models/ReferenceValue.java
@@ -1,0 +1,30 @@
+package com.tenable.io.api.workbenches.models;
+
+import java.util.List;
+
+/**
+ * Copyright (c) 2017 Tenable Network Security, Inc.
+ */
+public class ReferenceValue {
+    private List<String> value;
+
+    /**
+     * Gets value.
+     *
+     * @return the values
+     */
+    public List<String> getValue() {
+        return value;
+    }
+
+
+    /**
+     * Sets value.
+     *
+     * @param value the value
+     */
+    public void setValues( List<String> value ) {
+        this.value = value;
+    }
+
+}

--- a/src/main/java/com/tenable/io/api/workbenches/models/WbVulnerabilityInfoDetail.java
+++ b/src/main/java/com/tenable/io/api/workbenches/models/WbVulnerabilityInfoDetail.java
@@ -10,7 +10,7 @@ import java.util.List;
  * Copyright (c) 2017 Tenable Network Security, Inc.
  */
 public class WbVulnerabilityInfoDetail {
-    private String cpe;
+    private List<String> cpe;
     private String exploitAvailable;
     private String expoitabilityEase;
     private String patchPublicationDate;
@@ -23,7 +23,7 @@ public class WbVulnerabilityInfoDetail {
      *
      * @return the cpe
      */
-    public String getCpe() {
+    public List<String> getCpe() {
         return cpe;
     }
 
@@ -33,7 +33,7 @@ public class WbVulnerabilityInfoDetail {
      *
      * @param cpe the cpe
      */
-    public void setCpe( String cpe ) {
+    public void setCpe( List<String> cpe ) {
         this.cpe = cpe;
     }
 

--- a/src/test/java/com/tenable/io/api/ScansApiClientTest.java
+++ b/src/test/java/com/tenable/io/api/ScansApiClientTest.java
@@ -3,6 +3,7 @@ package com.tenable.io.api;
 
 import com.tenable.io.api.editors.models.Template;
 import com.tenable.io.api.permissions.models.Permission;
+import com.tenable.io.api.plugins.models.PluginOutputResult;
 import com.tenable.io.api.policies.models.Policy;
 import com.tenable.io.api.scanners.models.ScanDetail;
 import com.tenable.io.api.scanners.models.Scanner;
@@ -305,6 +306,33 @@ public class ScansApiClientTest extends TestBase {
         assertNotNull( hostDetails );
         assertNotNull( hostDetails.getVulnerabilities() );
         assertNotNull( hostDetails.getInfo().getOperatingSystem() );
+    }
+
+    @Test
+    public void testScanHostPluginDetails() throws Exception {
+        List<Scan> scans = apiClient.getScansApi().list().getScans();
+        assertNotNull( scans );
+
+        int scanId = scans.get(0).getId();
+        ScanDetails details = apiClient.getScansApi().details( scanId );
+        assertNotNull( details );
+
+        List<ScanHost> hosts = details.getHosts();
+        assertNotNull( hosts );
+
+        ScanHostDetails hostDetails = apiClient.getScansApi().hostDetails( scanId, hosts.get(0).getHostId() );
+        assertNotNull( hostDetails );
+        assertNotNull( hostDetails.getVulnerabilities() );
+
+        for (ScanHostVulnerability vulnerability : hostDetails.getVulnerabilities() ) {
+            int pluginId = vulnerability.getPluginId();
+            assertNotNull( pluginId );
+            PluginOutputResult pluginOutputResult = apiClient.getScansApi().pluginOutput( scanId, hosts.get(0).getHostId(), pluginId );
+            assertNotNull( pluginOutputResult );
+            if ( pluginOutputResult.getInfo().getPluginDescription().getPluginAttributes().getRefInformation() != null ) {
+                assertNotNull(pluginOutputResult.getInfo().getPluginDescription().getPluginAttributes().getRefInformation().getRef().get(0).getValues().get(0).getValue());
+            }
+        }
     }
 
 

--- a/src/test/java/com/tenable/io/api/TestBase.java
+++ b/src/test/java/com/tenable/io/api/TestBase.java
@@ -46,7 +46,7 @@ public class TestBase {
 
 
     protected TenableIoClient apiClient = new TenableIoClient();
-    private static final String testUsernameBase = "tioTestUsername";
+    private static final String testUsernameBase = "tioTestUsername-automation";
     private Set<String> testUsernames = new HashSet<>();
 
     // A valid domain name for username


### PR DESCRIPTION
There were several Scan/Workbench deserialization issues that were discovered after the recent update to Jackson Core 2.10.x.

Namely:
- `pluginId` in the `ScanHostCompliance` is an alphanumeric string rather than an integer. The documentation for this was originally incorrect. 
- `values` in the `Reference` objects for scan host plugin information is actually a list of single value objects rather than a list of `String`.
- `cpe` in `WbVulnerabilityInfoDetail` should be a List of `String` rather than `String`