### PR TITLE
Allow use of agent groups in scan configuration

### DIFF
--- a/src/main/java/com/tenable/io/api/agents/AgentsApi.java
+++ b/src/main/java/com/tenable/io/api/agents/AgentsApi.java
@@ -32,7 +32,7 @@ public class AgentsApi extends ApiWrapperBase {
     }
 
     /**
-     * List list.
+     * Returns the agent list for the default scanner with no filtering or sorting.
      *
      * @return the list
      * @throws TenableIoException the tenable io exception
@@ -42,9 +42,9 @@ public class AgentsApi extends ApiWrapperBase {
     }
 
     /**
-     * Returns the agent list for the default scanner
+     * Returns the agent list for the default scanner and accepting filtering, sorting, or limiting parameters.
      *
-     * @param filtering the filtering
+     * @param filtering A List of named values used for filtering, sorting, or limiting results. See https://developer.tenable.com/reference#agents
      * @return the agent list for the default scanner
      * @throws TenableIoException the tenable IO exception
      */
@@ -54,10 +54,10 @@ public class AgentsApi extends ApiWrapperBase {
 
 
     /**
-     * Returns the agent list for the given scanner
+     * Returns the agent list for the given scanner and accepting filtering, sorting, or limiting parameters.
      *
      * @param scannerId The id of the scanner to query for agents
-     * @param filtering the filtering
+     * @param filtering A List of named values used for filtering, sorting, or limiting results. See https://developer.tenable.com/reference#agents
      * @return the agent list for the given scanner
      * @throws TenableIoException the tenable IO exception
      */

--- a/src/main/java/com/tenable/io/api/editors/models/Input.java
+++ b/src/main/java/com/tenable/io/api/editors/models/Input.java
@@ -16,7 +16,7 @@ public class Input {
     private String hint;
     private String name;
     private boolean required;
-    private String defaultValue;
+    private Object defaultValue;
     private List<Option> options;
 
 
@@ -146,7 +146,7 @@ public class Input {
      * @return the default value for the input.
      */
     @JsonProperty( "default" )
-    public String getDefaultValue() {
+    public Object getDefaultValue() {
         return defaultValue;
     }
 
@@ -157,7 +157,7 @@ public class Input {
      * @param defaultValue the default value for the input.
      */
     @JsonProperty( "default" )
-    public void setDefaultValue( String defaultValue ) {
+    public void setDefaultValue( Object defaultValue ) {
         this.defaultValue = defaultValue;
     }
 

--- a/src/main/java/com/tenable/io/api/scans/models/Settings.java
+++ b/src/main/java/com/tenable/io/api/scans/models/Settings.java
@@ -28,6 +28,7 @@ public class Settings {
     private String emails;
     private List<Permission> acls;
     private String providedCredsOnly;
+    private List<String> agentGroupId;
 
     /**
      * Gets the name of the scan.
@@ -350,6 +351,33 @@ public class Settings {
     }
 
 
+    @JsonProperty( "provided_creds_only" )
+    public String getProvidedCredsOnly() {
+        return providedCredsOnly;
+    }
+
+    @JsonProperty( "provided_creds_only" )
+    public void setProvidedCredsOnly(String providedCredsOnly) {
+        this.providedCredsOnly = providedCredsOnly;
+    }
+
+    /**
+     * Get an array of the agent groups ids used for the scan
+     *
+     * @return an array containing agent groups id to apply to the scan
+     */
+    @JsonProperty( "agent_group_id" )
+    public List<String> getAgentGroupId() { return agentGroupId; }
+
+    /**
+     * Sets an array of the agent groups ids used for the scan
+     *
+     * @param agentGroupId an array containing agent groups id to apply to the scan
+     */
+    @JsonProperty( "agent_group_id" )
+    public void setAgentGroupId(List<String> agentGroupId) { this.agentGroupId = agentGroupId; }
+
+
     /**
      * Sets the name of the scan.
      *
@@ -507,15 +535,13 @@ public class Settings {
         return this;
     }
 
-
-    @JsonProperty( "provided_creds_only" )
-    public String getProvidedCredsOnly() {
-        return providedCredsOnly;
+    /**
+     * Sets agent group ids for the scan
+     *
+     * @param agentGroupId an array containing agent groups id to apply to the scan.
+     */
+    public Settings withAgentGroupId(List<String> agentGroupId) {
+        this.agentGroupId = agentGroupId;
+        return this;
     }
-
-    @JsonProperty( "provided_creds_only" )
-    public void setProvidedCredsOnly(String providedCredsOnly) {
-        this.providedCredsOnly = providedCredsOnly;
-    }
-
 }


### PR DESCRIPTION
Changes:
- Added additional docs for agents API, allow for setting agent_group_id at scan creation/update
- Updated Editor Input defaultValue property to be type Object rather than String due to value variability.
- Improved existing docs in Agents API for clarity

Should address #45 