### PR TITLE
version bump to 1.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
 group = 'com.tenable'
-version = '1.3-3'
+version = '1.4.0'
 
 description = """"""
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 CHANGE LOG
 =========
 
+1.4.0
+==========
+
+* Added: Support for dynamic tagging.
+* Fixed: Can not set agent_group_id during scan creation/update.
+* Fixed: Updated Editor Input defaultValue property to be type Object due to value variability.
+
 1.3.3
 ==========
 


### PR DESCRIPTION
* Added: Support for dynamic tagging.
* Fixed: Can not set agent_group_id during scan creation/update.
* Fixed: Updated Editor Input defaultValue property to be type Object due to value variability.