### PR TITLE
Fixed json property names in export filters

### DIFF
--- a/src/main/java/com/tenable/io/api/exports/models/VulnsExportFilters.java
+++ b/src/main/java/com/tenable/io/api/exports/models/VulnsExportFilters.java
@@ -88,8 +88,10 @@ public class VulnsExportFilters {
      *
      * @param firstFound
      */
+    @JsonProperty( "first_found" )
     public void setFirstFound( long firstFound ) { this.firstFound = firstFound; }
 
+    @JsonProperty( "first_found" )
     public long getFirstFound() { return this.firstFound; }
 
     /**
@@ -98,8 +100,10 @@ public class VulnsExportFilters {
      *
      * @param lastFound
      */
+    @JsonProperty( "last_found" )
     public void setLastFound( long lastFound ) { this.lastFound = lastFound; }
 
+    @JsonProperty( "last_found" )
     public long getLastFound() { return this.lastFound; }
 
     /**
@@ -108,8 +112,10 @@ public class VulnsExportFilters {
      *
      * @param lastFixed
      */
+    @JsonProperty( "last_fixed" )
     public void setLastFixed( long lastFixed ) { this.lastFixed = lastFixed; }
 
+    @JsonProperty( "last_fixed" )
     public long getLastFixed() { return this.lastFixed; }
 
     /**

--- a/src/main/java/com/tenable/io/api/exports/models/VulnsExportFilters.java
+++ b/src/main/java/com/tenable/io/api/exports/models/VulnsExportFilters.java
@@ -123,8 +123,10 @@ public class VulnsExportFilters {
      *
      * @param cidrRange the cidr range
      */
+    @JsonProperty( "cidr_range" )
     public void setCidrRange( String cidrRange ) { this.cidrRange = cidrRange; }
 
+    @JsonProperty( "cidr_range" )
     public String getCidrRange() { return this.cidrRange; }
 
     /**


### PR DESCRIPTION
This fixes the json property names of the following filters in the Export API:

- first_found
- last_found
- last_fixed
- cidr_range

Without this fix, the HTTP REST call is invalid and the server returns an error.